### PR TITLE
Fix CI workflow

### DIFF
--- a/ingest-service/pom.xml
+++ b/ingest-service/pom.xml
@@ -111,13 +111,11 @@
         </executions>
       </plugin>
       
-      <!-- JaCoCo disabled temporarily due to Java 24 compatibility issues -->
-      <!--
+      <!-- Enable JaCoCo for coverage reporting -->
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
-      -->
       
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/mvnw
+++ b/mvnw
@@ -25,6 +25,10 @@
 set -euf
 [ "${MVNW_VERBOSE-}" != "true" ] || set -x
 
+# Ensure MAVEN_PROJECTBASEDIR is set for compatibility with different
+# environments (e.g., GitHub Actions)
+[ -n "${MAVEN_PROJECTBASEDIR-}" ] || MAVEN_PROJECTBASEDIR="$(cd "$(dirname "$0")" && pwd -P)"
+
 # OS specific support.
 native_path() { printf %s\\n "$1"; }
 case "$(uname)" in


### PR DESCRIPTION
## Summary
- fix mvnw so MAVEN_PROJECTBASEDIR defaults when unset
- enable Jacoco plugin for coverage

## Testing
- `./mvnw -q -DskipTests --version` *(fails: Could not find or load main class org.apache.maven.wrapper.MavenWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68646604aedc8330851dc8d93ef8bebf